### PR TITLE
Make test batch size configurable

### DIFF
--- a/torchsr/dataset.py
+++ b/torchsr/dataset.py
@@ -293,6 +293,7 @@ def _train_dataset(train_subset: list, batch_size: int, crop_size: int = 96,
 
 def _test_dataset(test_subset: list,
                   upscale_factor: int = 4,
+                  batch_size: int = 1,
                   crop_size: int = 96,
                   dataset_multiplier: int = 1,
                   workers: int = 16,
@@ -310,6 +311,9 @@ def _test_dataset(test_subset: list,
     upscale_factor : int
         An ``int`` of the amount the image should be upscaled in each
         direction.
+    batch_size : int
+        An ``int`` of the number of images to include in each batch during
+        training.
     crop_size : int
         An ``int`` of the size to crop the high resolution images to in pixels.
         The size is used for both the height and width, ie. a crop_size of `96`
@@ -338,14 +342,14 @@ def _test_dataset(test_subset: list,
             dataset=test_data,
             sampler=test_sampler,
             num_workers=workers,
-            batch_size=1,
+            batch_size=batch_size,
             persistent_workers=True
         )
     else:
         testloader = DataLoader(
             dataset=test_data,
             num_workers=workers,
-            batch_size=1,
+            batch_size=batch_size,
             shuffle=False
         )
     return testloader
@@ -405,6 +409,7 @@ def initialize_datasets(train_directory: str, batch_size: int,
                                  workers=workers,
                                  distributed=distributed)
     testloader = _test_dataset(test_data, upscale_factor=upscale_factor,
+                               batch_size=batch_size,
                                crop_size=crop_size,
                                dataset_multiplier=dataset_multiplier,
                                workers=workers, distributed=distributed)

--- a/torchsr/esrgan/trainer.py
+++ b/torchsr/esrgan/trainer.py
@@ -299,7 +299,7 @@ class ESRGANTrainer:
 
             end_time = time.time()
             time_taken = end_time - start_time
-            throughput = len(self.test_loader) * self.world_size / time_taken
+            throughput = len(self.test_loader) * self.batch_size * self.world_size / time_taken
             psnr = psnr / len(self.test_loader)
             loss = loss / len(self.test_loader)
 

--- a/torchsr/srgan/trainer.py
+++ b/torchsr/srgan/trainer.py
@@ -299,7 +299,7 @@ class SRGANTrainer:
 
             end_time = time.time()
             time_taken = end_time - start_time
-            throughput = len(self.test_loader) * self.world_size / time_taken
+            throughput = len(self.test_loader) * self.batch_size * self.world_size / time_taken
             psnr = psnr / len(self.test_loader)
             loss = loss / len(self.test_loader)
 


### PR DESCRIPTION
The test dataset default to a batch size of 1 which made data loading a bottleneck in the validation process. Allowing the test dataset to be read in batches will significantly improve the validation throughput.

Signed-Off-By: Robert Clark <robdclark@outlook.com>