### PR TITLE
Update Slurm example

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Next, modify the `distributed.sh` script to the following:
 #SBATCH --ntasks-per-node=8
 
 srun \
-    --gres=gpu:8 \
+    --gpus-per-node=8 \
     --container-image <image name:tag here> \
     --container-mounts=/path/to/dataset:/dataset \
     bash -c 'wandb login && \


### PR DESCRIPTION
The Slurm example used `--gres=gpu:8` which isn't as stable or broadly applicable to differing Slurm-based GPU clusters compared to the `--gpus-per-node` variable.

Signed-Off-By: Robert Clark <robdclark@outlook.com>